### PR TITLE
Fix Charmer feat to increase CHA by 1

### DIFF
--- a/packs/feats/charmer.json
+++ b/packs/feats/charmer.json
@@ -8,7 +8,7 @@
       "_id": "O6MV5fgux54aJzON",
       "changes": [
         {
-          "key": "system.attributes.str.mod",
+          "key": "system.attributes.cha.mod",
           "value": "1",
           "mode": 2,
           "priority": 20


### PR DESCRIPTION
This fixes the Charmer feat to grant the ability score bonus from the PHB and in the description at [packs/feats/charmer.json#L123](https://github.com/afwolfe/sw5e/blob/93522bc6328639f6f1804e2a94d7e952d3c15399/packs/feats/charmer.json#L123)