### PR TITLE
Fix character Importer failing to process skills

### DIFF
--- a/module/character-importer.mjs
+++ b/module/character-importer.mjs
@@ -116,7 +116,9 @@ export default class CharacterImporter {
         value: sourceCharacter.attribs.find(e => e.name === "technology_type").current
       }
     };
-    for (const id of Object.keys(skills)) skills[id] = globalThis.sw5e.dataModels.actor.CharacterData._initialSkillValue(id, skills[id]);
+    for (const [id, skill] of Object.entries(skills)) {
+      skills[id] = globalThis.sw5e.dataModels.actor.CharacterData._initialSkillValue(id, skill);
+    }
 
     const targetCharacter = {
       name: sourceCharacter.name,


### PR DESCRIPTION
As pointed out by Aras on discord, the when the character importer tries to process the skills, it tries to iterate through them like an array, rather than like an object. This PR fixes this.