### PR TITLE
Fix starship-sheet rollPowerDie

### DIFF
--- a/module/applications/actor/starship-sheet.mjs
+++ b/module/applications/actor/starship-sheet.mjs
@@ -314,7 +314,7 @@ export default class ActorSheet5eStarship extends ActorSheet5e {
       case "rollInitiative":
         return this.actor.rollInitiativeDialog({ event });
       case "rollPowerDie":
-        return this.actor.rollPowerDie({ slot: event.target.dataset.location });
+        return this.actor.rollPowerDie(event.target.dataset.location);
     }
   }
 


### PR DESCRIPTION
This PR fixes the error/warning: `'[object Object]'' is not a valid power dice slot` when clicking on any of the Starship Power Dice slots or the "Power Die" label on sw5e 2.3.1.2.6.4.